### PR TITLE
Rename DB tables to use underscores instead of dots

### DIFF
--- a/DAL/StructuredContent.dbml
+++ b/DAL/StructuredContent.dbml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Database Name="dnn9" EntityNamespace="StructuredContent.DAL" ContextNamespace="StructuredContent.DAL" Class="DataContext" xmlns="http://schemas.microsoft.com/linqtosql/dbml/2007">
   <Connection Mode="WebSettings" ConnectionString="Data Source=.;Initial Catalog=dnn9;User ID=sa" SettingsObjectName="System.Configuration.ConfigurationManager.ConnectionStrings" SettingsPropertyName="SiteSqlServer" Provider="System.Data.SqlClient" />
-  <Table Name="dbo.[StructuredContent.VisualizerTemplate]" Member="StructuredContent_VisualizerTemplates">
+  <Table Name="dbo.[StructuredContent_VisualizerTemplate]" Member="StructuredContent_VisualizerTemplates">
     <Type Name="StructuredContent_VisualizerTemplate">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="content_type_id" Type="System.Int32" DbType="Int NOT NULL" CanBeNull="false" />
@@ -15,7 +15,7 @@
       <Association Name="StructuredContent_ContentType_StructuredContent_VisualizerTemplate" Member="StructuredContent_ContentType" ThisKey="content_type_id" OtherKey="id" Type="StructuredContent_ContentType" IsForeignKey="true" DeleteRule="CASCADE" DeleteOnNull="true" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.ContentType]" Member="StructuredContent_ContentTypes">
+  <Table Name="dbo.[StructuredContent_ContentType]" Member="StructuredContent_ContentTypes">
     <Type Name="StructuredContent_ContentType">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="name" Type="System.String" DbType="NVarChar(250) NOT NULL" CanBeNull="false" />
@@ -32,7 +32,7 @@
       <Association Name="StructuredContent_ContentType_StructuredContent_Visualizer" Member="StructuredContent_Visualizers" ThisKey="id" OtherKey="content_type_id" Type="StructuredContent_Visualizer" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.Relationship]" Member="StructuredContent_Relationships">
+  <Table Name="dbo.[StructuredContent_Relationship]" Member="StructuredContent_Relationships">
     <Type Name="StructuredContent_Relationship">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="[key]" Member="key" Type="System.String" DbType="VarChar(3) NOT NULL" CanBeNull="false" />
@@ -54,7 +54,7 @@
       <Association Name="StructuredContent_ContentType_StructuredContent_Relationship1" Member="StructuredContent_ContentType1" ThisKey="b_content_type_id" OtherKey="id" Type="StructuredContent_ContentType" IsForeignKey="true" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.Revision]" Member="StructuredContent_Revisions">
+  <Table Name="dbo.[StructuredContent_Revision]" Member="StructuredContent_Revisions">
     <Type Name="StructuredContent_Revision">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="revision_date" Type="System.DateTime" DbType="DateTime NOT NULL" CanBeNull="false" />
@@ -67,7 +67,7 @@
       <Association Name="StructuredContent_ContentType_StructuredContent_Revision" Member="StructuredContent_ContentType" ThisKey="content_type_id" OtherKey="id" Type="StructuredContent_ContentType" IsForeignKey="true" DeleteRule="CASCADE" DeleteOnNull="true" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.ContentField]" Member="StructuredContent_ContentFields">
+  <Table Name="dbo.[StructuredContent_ContentField]" Member="StructuredContent_ContentFields">
     <Type Name="StructuredContent_ContentField">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="name" Type="System.String" DbType="NVarChar(256) NOT NULL" CanBeNull="false" />
@@ -88,7 +88,7 @@
       <Association Name="StructuredContent_ContentFieldType_StructuredContent_ContentField" Member="StructuredContent_ContentFieldType" ThisKey="content_field_type_id" OtherKey="id" Type="StructuredContent_ContentFieldType" IsForeignKey="true" DeleteRule="SET NULL" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.Visualizer]" Member="StructuredContent_Visualizers">
+  <Table Name="dbo.[StructuredContent_Visualizer]" Member="StructuredContent_Visualizers">
     <Type Name="StructuredContent_Visualizer">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="module_id" Type="System.Int32" DbType="Int NOT NULL" CanBeNull="false" />
@@ -100,7 +100,7 @@
       <Association Name="StructuredContent_VisualizerTemplate_StructuredContent_Visualizer" Member="StructuredContent_VisualizerTemplate" ThisKey="visualizer_template_id" OtherKey="id" Type="StructuredContent_VisualizerTemplate" IsForeignKey="true" />
     </Type>
   </Table>
-  <Table Name="dbo.[StructuredContent.ContentFieldType]" Member="StructuredContent_ContentFieldTypes">
+  <Table Name="dbo.[StructuredContent_ContentFieldType]" Member="StructuredContent_ContentFieldTypes">
     <Type Name="StructuredContent_ContentFieldType">
       <Column Name="id" Type="System.Int32" DbType="Int NOT NULL IDENTITY" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
       <Column Name="[key]" Member="key" Type="System.String" DbType="VarChar(50) NOT NULL" CanBeNull="false" />

--- a/DAL/StructuredContent.designer.cs
+++ b/DAL/StructuredContent.designer.cs
@@ -140,7 +140,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.VisualizerTemplate]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_VisualizerTemplate]")]
 	public partial class StructuredContent_VisualizerTemplate : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -463,7 +463,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.ContentType]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_ContentType]")]
 	public partial class StructuredContent_ContentType : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -837,7 +837,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.Relationship]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_Relationship]")]
 	public partial class StructuredContent_Relationship : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -1341,7 +1341,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.Revision]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_Revision]")]
 	public partial class StructuredContent_Revision : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -1612,7 +1612,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.ContentField]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_ContentField]")]
 	public partial class StructuredContent_ContentField : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -2092,7 +2092,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.Visualizer]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_Visualizer]")]
 	public partial class StructuredContent_Visualizer : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		
@@ -2356,7 +2356,7 @@ namespace StructuredContent.DAL
 		}
 	}
 	
-	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent.ContentFieldType]")]
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="dbo.[StructuredContent_ContentFieldType]")]
 	public partial class StructuredContent_ContentFieldType : INotifyPropertyChanging, INotifyPropertyChanged
 	{
 		

--- a/DBScripts/00.01.00.SqlDataProvider
+++ b/DBScripts/00.01.00.SqlDataProvider
@@ -1,11 +1,11 @@
-﻿/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.ContentField]    Script Date: 9/18/2021 5:35:29 PM ******/
+﻿/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_ContentField]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentField]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentField]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentField](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[name] [nvarchar](256) NOT NULL,
 	[content_type_id] [int] NOT NULL,
@@ -21,21 +21,21 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField](
 	[options] [nvarchar](max) NULL,
 	[layout_row] [int] NULL,
 	[layout_column] [int] NULL,
- CONSTRAINT [PK_StructuredContent.ContentField] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_ContentField] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[key] [varchar](50) NOT NULL,
 	[type] [varchar](20) NOT NULL,
@@ -45,21 +45,21 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType
 	[default_data_length] [varchar](10) NULL,
 	[default_options] [nvarchar](500) NULL,
 	[icon] [nvarchar](50) NULL,
- CONSTRAINT [PK_StructuredContent.ContentFieldType] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_ContentFieldType] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.ContentType]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_ContentType]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentType]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentType]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentType](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentType](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[name] [nvarchar](250) NOT NULL,
 	[singular] [nvarchar](250) NOT NULL,
@@ -67,21 +67,21 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentType](
 	[url_slug] [nvarchar](250) NOT NULL,
 	[table_name] [nvarchar](250) NOT NULL,
 	[is_system] [bit] NOT NULL,
- CONSTRAINT [PK_StructuredContent.ContentType] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_ContentType] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.Relationship]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_Relationship]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Relationship]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Relationship]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_Relationship](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[key] [varchar](3) NOT NULL,
 	[a_content_type_id] [int] NOT NULL,
@@ -98,21 +98,21 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship](
 	[a_layout_column] [int] NULL,
 	[b_layout_row] [int] NULL,
 	[b_layout_column] [int] NULL,
- CONSTRAINT [PK_StructuredContent.Relationship] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_Relationship] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.Revision]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_Revision]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Revision]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Revision]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.Revision](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_Revision](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[revision_date] [datetime] NOT NULL,
 	[user_id] [int] NULL,
@@ -121,42 +121,42 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.Revision](
 	[item_id] [int] NOT NULL,
 	[delta] [nvarchar](max) NOT NULL,
 	[data] [nvarchar](max) NOT NULL,
- CONSTRAINT [PK_StructuredContent.Revision] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_Revision] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.Visualizer]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_Visualizer]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[module_id] [int] NOT NULL,
 	[content_type_id] [int] NOT NULL,
 	[visualizer_template_id] [int] NULL,
 	[item_id] [int] NULL,
 	[item_filter] [nvarchar](max) NULL,
- CONSTRAINT [PK_StructuredContent.Visualizer] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_Visualizer] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 END
 GO
-/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate]    Script Date: 9/18/2021 5:35:29 PM ******/
+/****** Object:  Table {databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate]    Script Date: 9/18/2021 5:35:29 PM ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate]') AND type in (N'U'))
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate]') AND type in (N'U'))
 BEGIN
-CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate](
+CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[content_type_id] [int] NOT NULL,
 	[name] [nvarchar](250) NOT NULL,
@@ -166,96 +166,96 @@ CREATE TABLE {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTempla
 	[template] [nvarchar](max) NULL,
 	[language] [varchar](10) NULL,
 	[content_size] [varchar](10) NULL,
- CONSTRAINT [PK_StructuredContent.VisualizerTemplate] PRIMARY KEY CLUSTERED 
+ CONSTRAINT [PK_StructuredContent_VisualizerTemplate] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 END
 GO
-SET IDENTITY_INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ON 
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (1, N'text', N'content_field', N'Text', 1, 0, N'50', NULL, N'fas fa-font')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (2, N'number', N'content_field', N'Number', 4, 1, NULL, NULL, N'fas fa-hashtag')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (3, N'email', N'content_field', N'Email', 5, 0, N'50', NULL, N'far fa-envelope')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (4, N'url', N'content_field', N'URL', 7, 0, N'50', NULL, N'fas fa-link')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (5, N'datetime', N'content_field', N'Date/Time', 8, 2, NULL, NULL, N'fas fa-calendar')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (6, N'boolean', N'content_field', N'Boolean', 10, 3, NULL, NULL, N'far fa-check-square')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (7, N'choice', N'content_field', N'Choice', 12, 0, N'50', N'{"choices":[{"text":"Choice 1","value":"choice1"},{"text":"Choice 2","value":"choice2"}, {"text":"Choice 3","value":"choice3"}], "default_value":null}', N'fas fa-list')
-INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (8, N'relatedcontent', N'relationship', N'Related Content Type', 16, 0, NULL, NULL, N'fas fa-sitemap')
-SET IDENTITY_INSERT {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] OFF
+SET IDENTITY_INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ON 
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (1, N'text', N'content_field', N'Text', 1, 0, N'50', NULL, N'fas fa-font')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (2, N'number', N'content_field', N'Number', 4, 1, NULL, NULL, N'fas fa-hashtag')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (3, N'email', N'content_field', N'Email', 5, 0, N'50', NULL, N'far fa-envelope')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (4, N'url', N'content_field', N'URL', 7, 0, N'50', NULL, N'fas fa-link')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (5, N'datetime', N'content_field', N'Date/Time', 8, 2, NULL, NULL, N'fas fa-calendar')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (6, N'boolean', N'content_field', N'Boolean', 10, 3, NULL, NULL, N'far fa-check-square')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (7, N'choice', N'content_field', N'Choice', 12, 0, N'50', N'{"choices":[{"text":"Choice 1","value":"choice1"},{"text":"Choice 2","value":"choice2"}, {"text":"Choice 3","value":"choice3"}], "default_value":null}', N'fas fa-list')
+INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id], [key], [type], [name], [ordinal], [default_data_type], [default_data_length], [default_options], [icon]) VALUES (8, N'relatedcontent', N'relationship', N'Related Content Type', 16, 0, NULL, NULL, N'fas fa-sitemap')
+SET IDENTITY_INSERT {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] OFF
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.ContentField_StructuredContent.ContentFieldType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentField]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.ContentField_StructuredContent.ContentFieldType] FOREIGN KEY([content_field_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentFieldType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_ContentField_StructuredContent_ContentFieldType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentField]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentField]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_ContentField_StructuredContent_ContentFieldType] FOREIGN KEY([content_field_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentFieldType] ([id])
 ON UPDATE CASCADE
 ON DELETE SET NULL
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.ContentField_StructuredContent.ContentFieldType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentField]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField] CHECK CONSTRAINT [FK_StructuredContent.ContentField_StructuredContent.ContentFieldType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_ContentField_StructuredContent_ContentFieldType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentField]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentField] CHECK CONSTRAINT [FK_StructuredContent_ContentField_StructuredContent_ContentFieldType]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.ContentField_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentField]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.ContentField_StructuredContent.ContentType] FOREIGN KEY([content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_ContentField_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentField]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentField]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_ContentField_StructuredContent_ContentType] FOREIGN KEY([content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 ON UPDATE CASCADE
 ON DELETE CASCADE
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.ContentField_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.ContentField]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.ContentField] CHECK CONSTRAINT [FK_StructuredContent.ContentField_StructuredContent.ContentType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_ContentField_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_ContentField]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_ContentField] CHECK CONSTRAINT [FK_StructuredContent_ContentField_StructuredContent_ContentType]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.RelationshipType_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Relationship]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.RelationshipType_StructuredContent.ContentType] FOREIGN KEY([a_content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_RelationshipType_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Relationship]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Relationship]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_RelationshipType_StructuredContent_ContentType] FOREIGN KEY([a_content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.RelationshipType_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Relationship]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship] CHECK CONSTRAINT [FK_StructuredContent.RelationshipType_StructuredContent.ContentType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_RelationshipType_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Relationship]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Relationship] CHECK CONSTRAINT [FK_StructuredContent_RelationshipType_StructuredContent_ContentType]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.RelationshipType_StructuredContent.ContentType1]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Relationship]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.RelationshipType_StructuredContent.ContentType1] FOREIGN KEY([b_content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_RelationshipType_StructuredContent_ContentType1]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Relationship]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Relationship]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_RelationshipType_StructuredContent_ContentType1] FOREIGN KEY([b_content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.RelationshipType_StructuredContent.ContentType1]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Relationship]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Relationship] CHECK CONSTRAINT [FK_StructuredContent.RelationshipType_StructuredContent.ContentType1]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_RelationshipType_StructuredContent_ContentType1]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Relationship]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Relationship] CHECK CONSTRAINT [FK_StructuredContent_RelationshipType_StructuredContent_ContentType1]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Revision_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Revision]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Revision]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.Revision_StructuredContent.ContentType] FOREIGN KEY([content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Revision_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Revision]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Revision]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_Revision_StructuredContent_ContentType] FOREIGN KEY([content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 ON UPDATE CASCADE
 ON DELETE CASCADE
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Revision_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Revision]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Revision] CHECK CONSTRAINT [FK_StructuredContent.Revision_StructuredContent.ContentType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Revision_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Revision]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Revision] CHECK CONSTRAINT [FK_StructuredContent_Revision_StructuredContent_ContentType]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_Modules]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.Visualizer_Modules] FOREIGN KEY([module_id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_Modules]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_Visualizer_Modules] FOREIGN KEY([module_id])
 REFERENCES {databaseOwner}{objectQualifier}[Modules] ([ModuleID])
 ON UPDATE CASCADE
 ON DELETE CASCADE
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_Modules]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer] CHECK CONSTRAINT [FK_StructuredContent.Visualizer_Modules]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_Modules]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer] CHECK CONSTRAINT [FK_StructuredContent_Visualizer_Modules]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.Visualizer_StructuredContent.ContentType] FOREIGN KEY([content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_Visualizer_StructuredContent_ContentType] FOREIGN KEY([content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 ON UPDATE CASCADE
 ON DELETE CASCADE
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer] CHECK CONSTRAINT [FK_StructuredContent.Visualizer_StructuredContent.ContentType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer] CHECK CONSTRAINT [FK_StructuredContent_Visualizer_StructuredContent_ContentType]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_StructuredContent.VisualizerTemplate]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.Visualizer_StructuredContent.VisualizerTemplate] FOREIGN KEY([visualizer_template_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_StructuredContent_VisualizerTemplate]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_Visualizer_StructuredContent_VisualizerTemplate] FOREIGN KEY([visualizer_template_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate] ([id])
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.Visualizer_StructuredContent.VisualizerTemplate]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.Visualizer]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.Visualizer] CHECK CONSTRAINT [FK_StructuredContent.Visualizer_StructuredContent.VisualizerTemplate]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_Visualizer_StructuredContent_VisualizerTemplate]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_Visualizer]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_Visualizer] CHECK CONSTRAINT [FK_StructuredContent_Visualizer_StructuredContent_VisualizerTemplate]
 GO
-IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.VisualizerTemplate_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent.VisualizerTemplate_StructuredContent.ContentType] FOREIGN KEY([content_type_id])
-REFERENCES {databaseOwner}{objectQualifier}[StructuredContent.ContentType] ([id])
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_VisualizerTemplate_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate]  WITH CHECK ADD  CONSTRAINT [FK_StructuredContent_VisualizerTemplate_StructuredContent_ContentType] FOREIGN KEY([content_type_id])
+REFERENCES {databaseOwner}{objectQualifier}[StructuredContent_ContentType] ([id])
 ON UPDATE CASCADE
 ON DELETE CASCADE
 GO
-IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent.VisualizerTemplate_StructuredContent.ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate]'))
-ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent.VisualizerTemplate] CHECK CONSTRAINT [FK_StructuredContent.VisualizerTemplate_StructuredContent.ContentType]
+IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[FK_StructuredContent_VisualizerTemplate_StructuredContent_ContentType]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate]'))
+ALTER TABLE {databaseOwner}{objectQualifier}[StructuredContent_VisualizerTemplate] CHECK CONSTRAINT [FK_StructuredContent_VisualizerTemplate_StructuredContent_ContentType]
 GO


### PR DESCRIPTION
In order to follow DNN table naming conventions, the table names have been changed to remove `.` and use `_` instead.