### PR TITLE
Added mergeable to enforce milestones and labels

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,12 @@
+﻿version: 2
+mergeable:
+  - when: pull_request.*, issues.*
+    validate:
+      - do: milestone
+        no_empty:
+          enabled: true
+          message: 'A milestone must be assigned to this pull request'
+      - do: label
+        no_empty:
+          enabled: true
+          message: 'A label must be assigned to this pull request'

--- a/Dnn.StructuredContent.csproj
+++ b/Dnn.StructuredContent.csproj
@@ -215,6 +215,7 @@
     <Content Include="plugins\ui.bootstrap\ui-bootstrap-tpls-2.5.0.min.js" />
     <Content Include="scripts\ContentLibrary.js" />
     <Content Include=".github\workflows\build.yml" />
+    <Content Include=".github\mergeable.yml" />
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
The automated release notes creation assume each PR will have a milestone and at least one label. This will enforce this before merging any PR.