### PR TITLE
Refactored SQLHelper to use Dependency Injection

### DIFF
--- a/Controllers/ContentFieldController.cs
+++ b/Controllers/ContentFieldController.cs
@@ -18,11 +18,18 @@ namespace StructuredContent
     using DotNetNuke.Web.Api;
     using StructuredContent.DAL;
 
-    // [SupportedModules("StructuredContent")]
+    /// <summary>
+    /// Manages Content Fields.
+    /// </summary>
     public class ContentFieldController : DnnApiController
     {
-        SQLHelper sqlHelper = new SQLHelper();
+        private ISQLHelper sqlHelper;
         DataContext dc = new DataContext();
+
+        public ContentFieldController(ISQLHelper sqlHelper)
+        {
+            this.sqlHelper = sqlHelper;
+        }
 
         [HttpGet]
         [AllowAnonymous]

--- a/Controllers/ContentItemController.cs
+++ b/Controllers/ContentItemController.cs
@@ -24,12 +24,12 @@ namespace StructuredContent
     public class ContentItemController : DnnApiController
     {
         private DataContext dataContext;
-        private SQLHelper sqlHelper;
+        private ISQLHelper sqlHelper;
 
-        public ContentItemController()
+        public ContentItemController(ISQLHelper sqlHelper)
         {
             this.dataContext = new DataContext();
-            this.sqlHelper = new SQLHelper();
+            this.sqlHelper = sqlHelper;
         }
 
         [HttpGet]

--- a/Controllers/ContentTypeController.cs
+++ b/Controllers/ContentTypeController.cs
@@ -17,12 +17,15 @@ namespace StructuredContent
     using DotNetNuke.Web.Api;
     using StructuredContent.DAL;
 
-    // [SupportedModules("StructuredContent")]
     public class ContentTypeController : DnnApiController
     {
-        // private string connectionString = ConfigurationManager.ConnectionStrings["SiteSqlServer"].ToString();
-        SQLHelper sqlHelper = new SQLHelper();
+        private ISQLHelper sqlHelper;
         DataContext dc = new DataContext();
+
+        public ContentTypeController(ISQLHelper sqlHelper)
+        {
+            this.sqlHelper = sqlHelper;
+        }
 
         [HttpGet]
         [AllowAnonymous]

--- a/Controllers/RelationshipController.cs
+++ b/Controllers/RelationshipController.cs
@@ -20,8 +20,13 @@ namespace StructuredContent
     // [SupportedModules("StructuredContent")]
     public class relationshipController : DnnApiController
     {
-        SQLHelper sqlHelper = new SQLHelper();
+        private ISQLHelper sqlHelper;
         DataContext dc = new DataContext();
+
+        public relationshipController(ISQLHelper sqlHelper)
+        {
+            this.sqlHelper = sqlHelper;
+        }
 
         [HttpGet]
         [AllowAnonymous]

--- a/Controllers/VisualizerController.cs
+++ b/Controllers/VisualizerController.cs
@@ -23,7 +23,12 @@ namespace StructuredContent
     public class VisualizerController : DnnApiController
     {
         DataContext dc = new DataContext();
-        SQLHelper sqlHelper = new SQLHelper();
+        private ISQLHelper sqlHelper;
+
+        public VisualizerController(ISQLHelper sqlHelper)
+        {
+            this.sqlHelper = sqlHelper;
+        }
 
         [HttpGet]
         [AllowAnonymous]

--- a/Controllers/VisualizerTemplateController.cs
+++ b/Controllers/VisualizerTemplateController.cs
@@ -22,7 +22,12 @@ namespace StructuredContent
     public class VisualizerTemplateController : DnnApiController
     {
         DataContext dc = new DataContext();
-        SQLHelper sqlHelper = new SQLHelper();
+        private ISQLHelper sqlHelper;
+
+        public VisualizerTemplateController(ISQLHelper sqlHelper)
+        {
+            this.sqlHelper = sqlHelper;
+        }
 
         [HttpGet]
         [AllowAnonymous]

--- a/DAL/ISQLHelper.cs
+++ b/DAL/ISQLHelper.cs
@@ -1,0 +1,161 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace StructuredContent.DAL
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Helper class for SQL interactions.
+    /// </summary>
+    public interface ISQLHelper
+    {
+        /// <summary>
+        /// Adds a column to a Structured Content table.
+        /// </summary>
+        /// <param name="content_field"><see cref="StructuredContent_ContentField"/>.</param>
+        void AddColumn(StructuredContent_ContentField content_field);
+
+        /// <summary>
+        /// Creates a custom table for Structured Content.
+        /// </summary>
+        /// <param name="content_type">The content type to create the table for, <see cref="StructuredContent_ContentType"/>.</param>
+        void CreateContentTable(StructuredContent_ContentType content_type);
+
+        /// <summary>
+        /// Creates the tables needed for a many-to-many relationship.
+        /// </summary>
+        /// <param name="a_content_type">The first content type for the relation.</param>
+        /// <param name="b_content_type">The second content type for the relation.</param>
+        void CreateManyToManyRelationship(StructuredContent_ContentType a_content_type, StructuredContent_ContentType b_content_type);
+
+        /// <summary>
+        /// Creates a one-to-many relationship in the database.
+        /// </summary>
+        /// <param name="one_content_type">The content type for the 'one' side.</param>
+        /// <param name="many_content_type">The content type for the 'many' side.</param>
+        void CreateOneToManyRelationship(StructuredContent_ContentType one_content_type, StructuredContent_ContentType many_content_type);
+
+        /// <summary>
+        /// Deletes a column for a given content item.
+        /// </summary>
+        /// <param name="content_field">The content field to delete.</param>
+        void DeleteColumn(StructuredContent_ContentField content_field);
+
+        /// <summary>
+        /// Deletes a row in the content table.
+        /// </summary>
+        /// <param name="content_type">The structured content type.</param>
+        /// <param name="id">The id of the item to delete.</param>
+        void DeleteContentItem(StructuredContent_ContentType content_type, int id);
+
+        /// <summary>
+        /// Deletes a whole content type table.
+        /// </summary>
+        /// <param name="content_type">The content type for which to delete the table for.</param>
+        void DeleteContentTable(StructuredContent_ContentType content_type);
+
+        /// <summary>
+        /// Removes a many-to-many relationship in the database.
+        /// </summary>
+        /// <param name="a_content_type">One of the content types.</param>
+        /// <param name="b_content_type">The other content type.</param>
+        void DeleteManyToManyRelationship(StructuredContent_ContentType a_content_type, StructuredContent_ContentType b_content_type);
+
+        /// <summary>
+        /// Deletes a single many-to-many relationship row.
+        /// </summary>
+        /// <param name="relationship">The relationship reference.</param>
+        /// <param name="primary_content_type">The primary content type.</param>
+        /// <param name="primary_content_item_id">The id of the primary content type.</param>
+        void DeleteManyToManyRelationship(StructuredContent_Relationship relationship, StructuredContent_ContentType primary_content_type, int primary_content_item_id);
+
+        /// <summary>
+        /// Deletes the many-to-many junction table as well as the metadata about it.
+        /// </summary>
+        /// <param name="one_content_type">One of the content types.</param>
+        /// <param name="many_content_type">The other content type in the relation.</param>
+        void DeleteOneToManyRelationship(StructuredContent_ContentType one_content_type, StructuredContent_ContentType many_content_type);
+
+        /// <summary>
+        /// Deletes a one-to-many relationship.
+        /// </summary>
+        /// <param name="primary_content_type">The content type on the primary side.</param>
+        /// <param name="related_content_type">The related content type (the many side).</param>
+        /// <param name="primary_content_item_id">The ID of the content item on the 'one' side of the relationship.</param>
+        void DeleteOneToManyRelationship(StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id);
+
+        /// <summary>
+        /// Executes an SQL query that has no return.
+        /// </summary>
+        /// <param name="query">The SQL query to execute.</param>
+        void ExecuteNonQuery(string query);
+
+        /// <summary>
+        /// Executes an SQL query that returns a single value.
+        /// </summary>
+        /// <param name="query">The SQL query to execute.</param>
+        /// <returns>An object containing the returned value.</returns>
+        object ExecuteScalar(string query);
+
+        /// <summary>
+        /// Gets the items related to another item.
+        /// </summary>
+        /// <param name="relationship">The ralationship definition metadata.</param>
+        /// <param name="content_type">The content type of the primary side of the raltion.</param>
+        /// <param name="id">The Id of the item to get the related items for.</param>
+        /// <returns>An enumeration of a dictionary where the key is the field name and the value is the field value.</returns>
+        IEnumerable<IDictionary<string, object>> GetRelatedItems(StructuredContent_Relationship relationship, StructuredContent_ContentType content_type, int id);
+
+        /// <summary>
+        /// Inserts a new content item in its table.
+        /// </summary>
+        /// <param name="content_type">The type of the item.</param>
+        /// <param name="content_item">The item itself.</param>
+        /// <returns>The Id of the inserted row.</returns>
+        int InsertContentItem(StructuredContent_ContentType content_type, dynamic content_item);
+
+        /// <summary>
+        /// Creates a many-to-many relationship between two items.
+        /// </summary>
+        /// <param name="relationship">The relationship definition.</param>
+        /// <param name="primary_content_type">The content type on the primary side.</param>
+        /// <param name="related_content_type">The content type on the ralted side.</param>
+        /// <param name="primary_content_item_id">The id of the item that should be related on the primary side.</param>
+        /// <param name="related_content_item_id">The id of the item that should be related on the ralated side.</param>
+        void SaveManyToManyRelationship(StructuredContent_Relationship relationship, StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id, int related_content_item_id);
+
+        /// <summary>
+        /// Creates a one-to-many relationship between two items.
+        /// </summary>
+        /// <param name="primary_content_type">The content type on the primary side.</param>
+        /// <param name="related_content_type">The content type on the related side.</param>
+        /// <param name="primary_content_item_id">The id of the item that should be related on the primary side.</param>
+        /// <param name="related_content_item_id">The id of the item that should be related on the related side.</param>
+        void SaveOneToManyRelationship(StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id, int related_content_item_id);
+
+        /// <summary>
+        /// Gets a single item by its id.
+        /// </summary>
+        /// <param name="content_type">The type of the content item.</param>
+        /// <param name="id">The id of the item.</param>
+        /// <returns>A dictionary representation of the database row where the key is the field name and the value is the field value.</returns>
+        IDictionary<string, object> SelectDynamicItem(StructuredContent_ContentType content_type, int id);
+
+        /// <summary>
+        /// Gets a list of items using an sql clause.
+        /// </summary>
+        /// <param name="content_type">The content type of the item.</param>
+        /// <param name="where_clause">The sql Where clause to use.</param>
+        /// <returns>An enumeration of dictionnaries where their key is the field name and their values are the field value.</returns>
+        IEnumerable<IDictionary<string, object>> SelectDynamicList(StructuredContent_ContentType content_type, string where_clause);
+
+        /// <summary>
+        /// Updates an item.
+        /// </summary>
+        /// <param name="content_type">The type of the item to update.</param>
+        /// <param name="content_item">The actual item information to update.</param>
+        void UpdateContentItem(StructuredContent_ContentType content_type, dynamic content_item);
+    }
+}

--- a/DAL/SQLHelper.cs
+++ b/DAL/SQLHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
-namespace StructuredContent
+namespace StructuredContent.DAL
 {
     using System;
     using System.Collections;
@@ -13,16 +13,17 @@ namespace StructuredContent
     using System.Linq;
     using System.Text;
 
-    using DotNetNuke.Web.Api;
-    using StructuredContent.DAL;
-
+    /// <summary>
+    /// A suite of SQL helper methods to access the data.
+    /// </summary>
     // TODO:  Need to add SQL inject security
-    public class SQLHelper
+    internal class SQLHelper : ISQLHelper
     {
         private const string TablePrefix = "StructuredContent_ContentType_";
 
         private string connectionString = ConfigurationManager.ConnectionStrings["SiteSqlServer"].ToString();
 
+        /// <inheritdoc/>
         public void ExecuteNonQuery(string query)
         {
             try
@@ -43,6 +44,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public object ExecuteScalar(string query)
         {
             try
@@ -64,6 +66,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void CreateContentTable(StructuredContent_ContentType content_type)
         {
             try
@@ -91,6 +94,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteContentTable(StructuredContent_ContentType content_type)
         {
             try
@@ -109,6 +113,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void AddColumn(StructuredContent_ContentField content_field)
         {
             try
@@ -148,6 +153,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteColumn(StructuredContent_ContentField content_field)
         {
             try
@@ -179,6 +185,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void CreateOneToManyRelationship(StructuredContent_ContentType one_content_type, StructuredContent_ContentType many_content_type)
         {
             try
@@ -203,6 +210,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteOneToManyRelationship(StructuredContent_ContentType one_content_type, StructuredContent_ContentType many_content_type)
         {
             try
@@ -222,6 +230,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void CreateManyToManyRelationship(StructuredContent_ContentType a_content_type, StructuredContent_ContentType b_content_type)
         {
             try
@@ -273,6 +282,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteManyToManyRelationship(StructuredContent_ContentType a_content_type, StructuredContent_ContentType b_content_type)
         {
             try
@@ -310,6 +320,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public IEnumerable<IDictionary<string, object>> SelectDynamicList(StructuredContent_ContentType content_type, string where_clause)
         {
             var table_name = TablePrefix + content_type.table_name;
@@ -348,6 +359,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public IDictionary<string, object> SelectDynamicItem(StructuredContent_ContentType content_type, int id)
         {
             try
@@ -402,6 +414,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public int InsertContentItem(StructuredContent_ContentType content_type, dynamic content_item)
         {
             try
@@ -499,6 +512,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void UpdateContentItem(StructuredContent_ContentType content_type, dynamic content_item)
         {
             try
@@ -575,6 +589,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteContentItem(StructuredContent_ContentType content_type, int id)
         {
             try
@@ -593,6 +608,7 @@ namespace StructuredContent
             }
         }
 
+        /// <inheritdoc/>
         public void DeleteManyToManyRelationship(StructuredContent_Relationship relationship, StructuredContent_ContentType primary_content_type, int primary_content_item_id)
         {
             string table_name = relationship.table_name;
@@ -605,6 +621,7 @@ namespace StructuredContent
             this.ExecuteNonQuery(sbDelete.ToString());
         }
 
+        /// <inheritdoc/>
         public void SaveManyToManyRelationship(StructuredContent_Relationship relationship, StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id, int related_content_item_id)
         {
             string table_name = relationship.table_name;
@@ -619,6 +636,7 @@ namespace StructuredContent
             this.ExecuteNonQuery(sbInsert.ToString());
         }
 
+        /// <inheritdoc/>
         public void DeleteOneToManyRelationship(StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id)
         {
             string related_content_table_name = TablePrefix + related_content_type.table_name;
@@ -632,6 +650,7 @@ namespace StructuredContent
             this.ExecuteNonQuery(sbMany.ToString());
         }
 
+        /// <inheritdoc/>
         public void SaveOneToManyRelationship(StructuredContent_ContentType primary_content_type, StructuredContent_ContentType related_content_type, int primary_content_item_id, int related_content_item_id)
         {
             string related_content_table_name = TablePrefix + related_content_type.table_name;
@@ -645,7 +664,7 @@ namespace StructuredContent
             this.ExecuteNonQuery(sbMany.ToString());
         }
 
-        // this returns all the related objects for a given object
+        /// <inheritdoc/>
         public IEnumerable<IDictionary<string, object>> GetRelatedItems(StructuredContent_Relationship relationship, StructuredContent_ContentType content_type, int id)
         {
             string source_table_name = string.Empty;

--- a/Dnn.StructuredContent.csproj
+++ b/Dnn.StructuredContent.csproj
@@ -44,8 +44,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
+    <DocumentationFile>bin\Debug\Dnn.StructuredContent.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -57,6 +56,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Release\Dnn.StructuredContent.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -80,6 +80,7 @@
     <Compile Include="Controllers\RevisionController.cs" />
     <Compile Include="Controllers\RelationshipController.cs" />
     <Compile Include="Controllers\ContentFieldTypeController.cs" />
+    <Compile Include="DAL\ISQLHelper.cs" />
     <Compile Include="DAL\Relationship.cs" />
     <Compile Include="DAL\ContentField.cs" />
     <Compile Include="DTOs\Visualizer.cs" />
@@ -92,6 +93,7 @@
     <Compile Include="DTOs\Relationship.cs" />
     <Compile Include="Enums\DataType.cs" />
     <Compile Include="Enums\ContentItemStatus.cs" />
+    <Compile Include="Startup.cs" />
     <Compile Include="Visualizer.ascx.cs">
       <DependentUpon>Visualizer.ascx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>
@@ -243,9 +245,7 @@
     <Content Include="manifest.dnn" />
     <Content Include="DBScripts\00.01.00.SqlDataProvider" />
     <Content Include="readme.md" />
-    <AdditionalFiles Include="stylecop.json">
-      <Link>stylecop.json</Link>
-    </AdditionalFiles>
+    <AdditionalFiles Include="stylecop.json" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/RouteMapper.cs
+++ b/RouteMapper.cs
@@ -10,6 +10,7 @@ namespace StructuredContent.DAL
 
     public class RouteMapper : IServiceRouteMapper
     {
+        /// <inheritdoc/>
         public void RegisterRoutes(IMapRoute mapRouteManager)
         {
             // Content Type

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace Dnn.StructuredContent
+{
+    using System;
+
+    using DotNetNuke.DependencyInjection;
+    using global::StructuredContent.DAL;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Fires up upon DNN Startup.
+    /// </summary>
+    public class Startup : IDnnStartup
+    {
+        /// <inheritdoc/>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<ISQLHelper, SQLHelper>();
+        }
+    }
+}


### PR DESCRIPTION
This has several benefits:

- We rely on an interface instead of a concrete piece of code. We know what the class does without caring about how it does it. This brings flexibility in refactoring that class if need be by editing a single file or to offer multiple ways to do things or to completely replace it say one day SQL server is no longer what we want to use.
- Performance and scalability: before this change, instances of this class could have been created in 14 places, with 1000 users within a few minutes that could well be 14000 instances that need to be created and then garbage collected which would consume much memory and CPU cycles. Since this class is almost stateless (the only state it carries is the connection string) I made it a singleton, so only one instance will ever exist. Should the connection string change, it causes a DNN to restart anyway and a new instance will replace it with the new connection string.
- Loose coupling: 14 other classes relied on this class, now only the startup class relies on it, the others only know about the interface.
- Testing: Should we add unit tests, we can mock this interface with our own implementation built just for testing. This allows us to test the classes that formerly relied on it to be tested in isolation without calling the real implementation that obviously needs a database connection to be available and would fail during tests.
- Good example: This is how we want new DNN development to be done and this module could be a great example to show how to do it right.