### PR TITLE
Bumps DNN dependency to v9.10.2

### DIFF
--- a/Dnn.StructuredContent.csproj
+++ b/Dnn.StructuredContent.csproj
@@ -314,10 +314,10 @@
       <Version>2.2.548</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Web.Client">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.WebApi">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="EntityFramework">
       <Version>6.4.4</Version>

--- a/manifest.dnn
+++ b/manifest.dnn
@@ -16,7 +16,7 @@
         Release notes are available on &lt;a href="https://github.com/DNNCommunity/Dnn.StructuredContent/releases" target="_blank"&gt;GitHub&lt;/a&gt;.
       </releaseNotes>
       <dependencies>
-        <dependency type="CoreVersion">09.10.01</dependency>
+        <dependency type="CoreVersion">09.10.02</dependency>
       </dependencies>
       <azureCompatible>true</azureCompatible>
       <components>


### PR DESCRIPTION
Bumps DNN dependency to v9.10.2, replacing dependabot PRs
