### PR TITLE
Enforces a build on windows 2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout source
         uses: actions/checkout@v2


### PR DESCRIPTION
Github migrated windows-latest to use Windows 2022 and the current build has some issues with that.

Doing this as a quick fix to allow current PRs to build, I have a recipe to revamp this and even make it run on ubuntu runners for even faster builds and less build-minutes and for some reason a windows minute counts for 2 minutes on github.

This is a release management task and I will be self-merging this so the other PRs build.